### PR TITLE
[CDSR-2300] add ACC14 test cases supporting mixed subsidy payments

### DIFF
--- a/app/uk/gov/hmrc/cdsreimbursementclaimstubs/models/MockHttpResponse.scala
+++ b/app/uk/gov/hmrc/cdsreimbursementclaimstubs/models/MockHttpResponse.scala
@@ -585,7 +585,60 @@ object MockHttpResponse {
         _ === MRN("10DDDDDDDDDDDDDDD1"),
         _ === EORI("GB000000000000001"),
         SubmitClaimResponse(Right(Tpi05ResponseType.OK_RESPONSE)),
-        DeclarationResponse(Right(Acc14ResponseType.OK_FULL_RESPONSE_SUBSIDY("10DDDDDDDDDDDDDDD1","GB000000000000001","GB000000000000001")))
+        DeclarationResponse(
+          Right(
+            Acc14ResponseType
+              .OK_FULL_RESPONSE_SUBSIDY("10DDDDDDDDDDDDDDD1", "GB000000000000001", "GB000000000000001", Seq("006"))
+          )
+        )
+      ),
+      MockHttpResponse(
+        _ === MRN("10DDDDDDDDDDDDDDD2"),
+        _ === EORI("GB000000000000001"),
+        SubmitClaimResponse(Right(Tpi05ResponseType.OK_RESPONSE)),
+        DeclarationResponse(
+          Right(
+            Acc14ResponseType
+              .OK_FULL_RESPONSE_SUBSIDY(
+                "10DDDDDDDDDDDDDDD2",
+                "GB000000000000001",
+                "GB000000000000001",
+                Seq("006", "001")
+              )
+          )
+        )
+      ),
+      MockHttpResponse(
+        _ === MRN("10DDDDDDDDDDDDDDD3"),
+        _ === EORI("GB000000000000001"),
+        SubmitClaimResponse(Right(Tpi05ResponseType.OK_RESPONSE)),
+        DeclarationResponse(
+          Right(
+            Acc14ResponseType
+              .OK_FULL_RESPONSE_SUBSIDY(
+                "10DDDDDDDDDDDDDDD3",
+                "GB000000000000001",
+                "GB000000000000001",
+                Seq("006", "003")
+              )
+          )
+        )
+      ),
+      MockHttpResponse(
+        _ === MRN("10DDDDDDDDDDDDDDD4"),
+        _ === EORI("GB000000000000001"),
+        SubmitClaimResponse(Right(Tpi05ResponseType.OK_RESPONSE)),
+        DeclarationResponse(
+          Right(
+            Acc14ResponseType
+              .OK_FULL_RESPONSE_SUBSIDY(
+                "10DDDDDDDDDDDDDDD4",
+                "GB000000000000001",
+                "GB000000000000001",
+                Seq("006", "001", "002", "003")
+              )
+          )
+        )
       ),
       MockHttpResponse(
         _ === MRN("10ABCDEFGHIJKLMNO0"),

--- a/test/uk/gov/hmrc/cdsreimbursementclaimstubs/controllers/DeclarationControllerSpec.scala
+++ b/test/uk/gov/hmrc/cdsreimbursementclaimstubs/controllers/DeclarationControllerSpec.scala
@@ -181,7 +181,11 @@ class DeclarationControllerSpec extends AnyWordSpec with Matchers with TypeCheck
     "10XICAAAAAAAAAAAA9",
     "10XICAAAAAAAAAAAB9",
     "10XICAAAAAAAAAAAC9",
-    "10XICAAAAAAAAAAAD9"
+    "10XICAAAAAAAAAAAD9",
+    "10DDDDDDDDDDDDDDD1",
+    "10DDDDDDDDDDDDDDD2",
+    "10DDDDDDDDDDDDDDD3",
+    "10DDDDDDDDDDDDDDD4"
   )
 
   val ndrcFailingMRNs = Seq(


### PR DESCRIPTION
This PR adds 3 new ACC14 stubs:
- 10DDDDDDDDDDDDDDD2 with 006 and 001
- 10DDDDDDDDDDDDDDD3 with 006 and 003
- 10DDDDDDDDDDDDDDD4 with 006, 001, 002, and 003